### PR TITLE
Добавлена страница выбора автотестов

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,33 @@ def index():
 def run_page():
     return render_template('run.html')
 
+
+@app.route('/select_tests')
+def select_tests_page():
+    """Страница выбора нескольких автотестов."""
+    return render_template('select_tests.html')
+
+
+@app.route('/api/run_selected', methods=['POST'])
+def run_selected():
+    """Запускает выбранные автотесты последовательно."""
+    data = request.get_json() or {}
+    tests = data.get('tests', [])
+    results = []
+    if 'acceptance' in tests:
+        results.append('=== Acceptance ===\n' + start.run())
+    if 'regression' in tests:
+        try:
+            import Regression as regression
+            results.append('=== Regression ===\n' + regression.run())
+        except Exception as e:
+            results.append(f'Ошибка запуска Regression: {e}')
+    if 'firmware' in tests:
+        results.append('=== Firmware ===\n' + start_test_firmware.run())
+    if not results:
+        return jsonify(result='Нет выбранных тестов')
+    return jsonify(result='\n\n'.join(results))
+
 @app.route('/start1')
 def start1_view():
     print(f"[{datetime.now()}] Запуск Acceptance теста через /start1")

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
                 <ul>
                     <li><a href="{{ url_for('index') }}">Главная</a></li>
                     <li><a href="{{ url_for('run_page') }}">Запуск</a></li>
+                    <li><a href="{{ url_for('select_tests_page') }}">Выбор тестов</a></li>
                     <li><a href="{{ url_for('logs') }}">Логи</a></li>
                     <li><a href="{{ url_for('config_page') }}">Конфиг</a></li>
                     <li><a href="{{ url_for('extra.ser') }}">Прошивки TOP</a></li>

--- a/templates/select_tests.html
+++ b/templates/select_tests.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Выбор автотестов</h2>
+<form id="testsForm">
+  <label><input type="checkbox" value="acceptance"> Acceptance</label><br>
+  <label><input type="checkbox" value="regression"> Regression</label><br>
+  <label><input type="checkbox" value="firmware"> Тест прошивки</label><br>
+  <button type="button" id="runSelectedBtn">Запустить выбранные</button>
+</form>
+<div id="selectedOutput" style="white-space: pre-wrap; margin-top:1rem;"></div>
+{% endblock %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('runSelectedBtn');
+  const output = document.getElementById('selectedOutput');
+  btn.addEventListener('click', () => {
+    const checks = document.querySelectorAll('#testsForm input[type="checkbox"]:checked');
+    const tests = Array.from(checks).map(el => el.value);
+    output.textContent = 'Запуск...';
+    fetch('/api/run_selected', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({tests})
+    })
+    .then(r => r.json())
+    .then(data => { output.textContent = data.result; })
+    .catch(() => { output.textContent = 'Ошибка запуска.'; });
+  });
+});
+</script>


### PR DESCRIPTION
## Summary
- add page with checkboxes to pick tests
- link new page in sidebar
- add routes to start selected tests sequentially

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684fa04b2d2c8329920cf47f53c9bc6f