### PR TITLE
Add selectable tests page

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,20 @@ def index():
 def run_page():
     return render_template('run.html')
 
+# Новая страница выбора автотестов
+@app.route('/tests')
+def tests_page():
+    from test_launcher import AVAILABLE_TESTS
+    return render_template('tests.html', tests=AVAILABLE_TESTS.keys())
+
+@app.route('/run_selected_tests', methods=['POST'])
+def run_selected_tests():
+    data = request.get_json() or {}
+    tests = data.get('tests', [])
+    from test_launcher import run_selected
+    results = run_selected(tests)
+    return jsonify(results=results)
+
 @app.route('/start1')
 def start1_view():
     print(f"[{datetime.now()}] Запуск Acceptance теста через /start1")

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,8 +22,9 @@
             <nav>
                 <ul>
                     <li><a href="{{ url_for('index') }}">Главная</a></li>
-                    <li><a href="{{ url_for('run_page') }}">Запуск</a></li>
-                    <li><a href="{{ url_for('logs') }}">Логи</a></li>
+                <li><a href="{{ url_for('run_page') }}">Запуск</a></li>
+                <li><a href="{{ url_for('tests_page') }}">Тесты</a></li>
+                <li><a href="{{ url_for('logs') }}">Логи</a></li>
                     <li><a href="{{ url_for('config_page') }}">Конфиг</a></li>
                     <li><a href="{{ url_for('extra.ser') }}">Прошивки TOP</a></li>
                 </ul>

--- a/templates/tests.html
+++ b/templates/tests.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Выбор автотестов</h2>
+<form id="tests-form">
+  {% for t in tests %}
+  <label><input type="checkbox" name="tests" value="{{ t }}"> {{ t }}</label><br>
+  {% endfor %}
+  <button type="submit">Запуск</button>
+</form>
+<pre id="tests-output"></pre>
+<script>
+  document.getElementById('tests-form').addEventListener('submit', function(e){
+    e.preventDefault();
+    const checked = Array.from(document.querySelectorAll('input[name="tests"]:checked')).map(el => el.value);
+    fetch('/run_selected_tests', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({tests: checked})
+    }).then(r => r.json()).then(data => {
+      document.getElementById('tests-output').textContent = JSON.stringify(data, null, 2);
+    }).catch(() => {
+      document.getElementById('tests-output').textContent = 'Ошибка запуска';
+    });
+  });
+</script>
+{% endblock %}

--- a/test_launcher.py
+++ b/test_launcher.py
@@ -1,0 +1,35 @@
+# test_launcher.py
+"""Utility functions to run selected tests from the progTest package."""
+from typing import List, Dict, Callable
+from progTest import screenshot, ParsProshivka
+import acceptance
+
+# Map of available test names to callables expecting (ip, login, password)
+AVAILABLE_TESTS: Dict[str, Callable[[str, str, str], object]] = {
+    'screenshot': screenshot.run,
+    'version': lambda ip, login, password: ParsProshivka.get_device_info(ip, login, password),
+}
+
+
+def run_selected(test_names: List[str], config_path: str = 'config.txt') -> List[Dict]:
+    """Run selected tests for each device from the config file.
+
+    Returns list of results for each device.
+    """
+    devices = acceptance.load_device_configs(config_path)
+    results = []
+    for cfg in devices:
+        device_res = {'device': cfg.get('IP_CAMERA', '')}
+        ip = cfg.get('IP_CAMERA', '')
+        login = cfg.get('LOGIN', '')
+        password = cfg.get('PASSWORD', '')
+        for name in test_names:
+            func = AVAILABLE_TESTS.get(name)
+            if not func:
+                continue
+            try:
+                device_res[name] = func(ip, login, password)
+            except Exception as e:
+                device_res[name] = f'Error: {e}'
+        results.append(device_res)
+    return results


### PR DESCRIPTION
## Summary
- add simple `test_launcher` helper to execute selected tests
- show new menu item 'Тесты'
- implement `/tests` page to choose tests and run them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684fa04b2d2c8329920cf47f53c9bc6f