### PR TITLE
Add custom test selection feature

### DIFF
--- a/static/js/select_tests.js
+++ b/static/js/select_tests.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('tests-form');
+  const output = document.getElementById('custom-output');
+  if (!form) return;
+  form.addEventListener('submit', evt => {
+    evt.preventDefault();
+    output.textContent = 'Выполнение...';
+    const checked = Array.from(form.querySelectorAll('input[name="tests"]:checked')).map(el => el.value);
+    fetch('/api/run-tests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tests: checked })
+    })
+    .then(r => r.json())
+    .then(data => {
+      output.textContent = data.result || 'Нет результата';
+    })
+    .catch(() => {
+      output.textContent = 'Ошибка запуска';
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
                 <ul>
                     <li><a href="{{ url_for('index') }}">Главная</a></li>
                     <li><a href="{{ url_for('run_page') }}">Запуск</a></li>
+                    <li><a href="{{ url_for('select_tests') }}">Выбор тестов</a></li>
                     <li><a href="{{ url_for('logs') }}">Логи</a></li>
                     <li><a href="{{ url_for('config_page') }}">Конфиг</a></li>
                     <li><a href="{{ url_for('extra.ser') }}">Прошивки TOP</a></li>
@@ -36,7 +37,8 @@
         </main>
     </div>
 
-    <!-- Подключаем скрипт для интерактивности -->
+    <!-- Подключаем скрипты -->
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/select_tests.js') }}"></script>
 </body>
 </html>

--- a/templates/select_tests.html
+++ b/templates/select_tests.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Выбор автотестов</h2>
+  <form id="tests-form">
+    {% for name in tests %}
+      <div>
+        <label>
+          <input type="checkbox" name="tests" value="{{ name }}"> {{ name }}
+        </label>
+      </div>
+    {% endfor %}
+    <button type="submit">Запустить</button>
+  </form>
+  <pre id="custom-output" style="white-space: pre-line; margin-top:1rem;"></pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new page to select and run specific tests
- wire new `select-tests` page into navigation
- support launching selected tests via `/api/run-tests`
- include new JS for custom page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684fa04b2d2c8329920cf47f53c9bc6f