### PR TITLE
Implement dynamic config editor

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -137,6 +137,28 @@ button:disabled {
   margin-top: 0.5rem;
 }
 
+.doorphone-block {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.var-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.var-row input {
+  margin-right: 0.5rem;
+}
+
+.delete-var {
+  cursor: pointer;
+  color: red;
+  margin-left: 0.5rem;
+}
+
 
 
 #logs-container {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -108,4 +108,97 @@ if (start3Btn) {
   });
 }
 
+  // ================= CONFIG EDITOR =================
+  const configDataEl = document.getElementById('config-data');
+  const doorphonesEl = document.getElementById('doorphones');
+
+  if (configDataEl && doorphonesEl) {
+    const initialConfig = JSON.parse(configDataEl.textContent || '""');
+
+    function createVarRow(name = '', value = '') {
+      const row = document.createElement('div');
+      row.className = 'var-row';
+
+      const nameInput = document.createElement('input');
+      nameInput.type = 'text';
+      nameInput.className = 'var-name';
+      nameInput.value = name;
+
+      const valueInput = document.createElement('input');
+      valueInput.type = 'text';
+      valueInput.className = 'var-value';
+      valueInput.value = value;
+
+      const del = document.createElement('span');
+      del.textContent = '🗑️';
+      del.className = 'delete-var';
+      del.addEventListener('click', () => row.remove());
+
+      row.appendChild(nameInput);
+      row.appendChild(valueInput);
+      row.appendChild(del);
+      return row;
+    }
+
+    function createDoorphoneBlock() {
+      const block = document.createElement('div');
+      block.className = 'doorphone-block';
+      doorphonesEl.appendChild(block);
+      return block;
+    }
+
+    // Parse initial config
+    let currentBlock = createDoorphoneBlock();
+    initialConfig.split(/\r?\n/).forEach(line => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      if (trimmed === '__________________') {
+        currentBlock = createDoorphoneBlock();
+      } else {
+        const idx = trimmed.indexOf('=');
+        if (idx !== -1) {
+          const name = trimmed.slice(0, idx).trim();
+          const value = trimmed.slice(idx + 1).trim();
+          currentBlock.appendChild(createVarRow(name, value));
+        }
+      }
+    });
+
+    const addVarBtn = document.getElementById('addVarBtn');
+    addVarBtn.addEventListener('click', () => {
+      let blocks = doorphonesEl.getElementsByClassName('doorphone-block');
+      if (blocks.length === 0) {
+        currentBlock = createDoorphoneBlock();
+      } else {
+        currentBlock = blocks[blocks.length - 1];
+      }
+      currentBlock.appendChild(createVarRow());
+    });
+
+    const addDoorphoneBtn = document.getElementById('addDoorphoneBtn');
+    addDoorphoneBtn.addEventListener('click', () => {
+      currentBlock = createDoorphoneBlock();
+    });
+
+    const form = document.getElementById('configForm');
+    form.addEventListener('submit', () => {
+      const blocks = doorphonesEl.getElementsByClassName('doorphone-block');
+      let lines = [];
+      for (let i = 0; i < blocks.length; i++) {
+        const rows = blocks[i].querySelectorAll('.var-row');
+        rows.forEach(row => {
+          const n = row.querySelector('.var-name').value.trim();
+          const v = row.querySelector('.var-value').value.trim();
+          if (n) {
+            lines.push(n + '=' + v);
+          }
+        });
+        if (i < blocks.length - 1) {
+          lines.push('__________________');
+        }
+      }
+      document.getElementById('configInput').value = lines.join('\n');
+    });
+  }
+
 });

--- a/templates/config.html
+++ b/templates/config.html
@@ -2,39 +2,47 @@
 
 {% block content %}
   <h2>Конфигурация</h2>
-  <!-- Форма для редактирования config.txt -->
-  <form method="post">
-    <textarea name="config" rows="15" style="width:100%;height: 240px;">{{ config | e }}</textarea>
-    <button type="submit">Сохранить</button>
-  </form>
-  <div><h2>Пример как должен выглядить Конфиг</h2>
-  <form method="post">
-    <textarea readonly name="config" rows="15" style="width:100%;height: 320px;">
-IP_CAMERA=192.168.0.245:85  # Здесь записывается IP-камеры с портом  
-LOGIN=admin                 # Логин от домофона (по стандарту admin)  
-PASSWORD=123456             # Пароль можно узнать на сайте https://192.168.0.100 (на данный момент не в рабочем состоянии)  
+  <div class="config-container">
+    <div class="edit-form">
+      <div id="doorphones"></div>
+      <button type="button" id="addVarBtn">Добавить переменную</button>
+      <button type="button" id="addDoorphoneBtn">Добавить домофон</button>
+      <form method="post" id="configForm">
+        <input type="hidden" name="config" id="configInput">
+        <button type="submit">Сохранить</button>
+      </form>
+    </div>
+    <div class="example-block">
+      <h2>Пример как должен выглядить Конфиг</h2>
+      <textarea readonly rows="15" style="width:100%;height: 320px;">
+IP_CAMERA=192.168.0.245:85  # Здесь записывается IP-камеры с портом
+LOGIN=admin                 # Логин от домофона (по стандарту admin)
+PASSWORD=123456             # Пароль можно узнать на сайте https://192.168.0.100 (на данный момент не в рабочем состоянии)
 MAX_SCREENSHOTS=500         # Количество скриншотов для теста (по умолчанию 1000)
 MAX_FIRMWARE_UPLOADS=4      # Количество циклов загрузки прошивки
 FIRMWARE_VERSIONS=2.5.03.21:firmware/2.5.03.21/rootfs.squashfs.gk7205v200.signed,2.5.04.08:firmware/2.5.04.08/rootfs.squashfs.gk7205v200.signed # Путь и название файлов прошивки
 
-Если имеются дополнительные настройки, например, времени или чего-либо, они должны выглядеть следующим образом:  
+Если имеются дополнительные настройки, например, времени или чего-либо, они должны выглядеть следующим образом:
 Time=100
-      
-Для добавления дополнительного домофона к имеющемуся списку нужно добавить разделитель "__________________".  
-      
-Пример:  
-      
-IP_CAMERA=192.168.0.245:85  
-LOGIN=admin  
-PASSWORD=123456  
+
+Для добавления дополнительного домофона к имеющемуся списку нужно добавить разделитель "__________________".
+
+Пример:
+
+IP_CAMERA=192.168.0.245:85
+LOGIN=admin
+PASSWORD=123456
 Time=100(На данный момент не как не используеться для примера)
-__________________  
-      
-IP_CAMERA=192.168.0.246:85  
-LOGIN=admin  
-PASSWORD=123456        
-и т. д.  
-    </textarea>
-  </form>
-</div>
+__________________
+
+IP_CAMERA=192.168.0.246:85
+LOGIN=admin
+PASSWORD=123456
+и т. д.
+      </textarea>
+    </div>
+  </div>
+
+  <script id="config-data" type="application/json">{{ config|tojson }}</script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- transform `config.html` to support interactive editing
- add JS logic to parse `config.txt`, allow adding/removing variables and doorphones
- style new blocks in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684fe93692c88329bdfa61f016e39758