### PR TITLE
Implement stop feature

### DIFF
--- a/Stop_routes.py
+++ b/Stop_routes.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, BackgroundTasks
+from fastapi.responses import JSONResponse
+import multiprocessing
+from typing import Optional, Callable
+
+router = APIRouter()
+
+_process: Optional[multiprocessing.Process] = None
+_last_result: Optional[str] = None
+
+
+def _run_target(func: Callable[[], str]):
+    global _last_result
+    try:
+        _last_result = func()
+    except Exception as exc:
+        _last_result = f'Ошибка: {exc}'
+
+
+@router.post('/run/{mode}')
+async def run_mode(mode: str, background_tasks: BackgroundTasks):
+    global _process
+    if _process and _process.is_alive():
+        return JSONResponse({'status': 'busy'})
+    if mode == 'regression':
+        import Regression as regression
+        target = regression.run
+    else:
+        import acceptance
+        target = acceptance.run
+    proc = multiprocessing.Process(target=_run_target, args=(target,))
+    _process = proc
+    proc.start()
+    background_tasks.add_task(proc.join)
+    return JSONResponse({'status': 'started', 'mode': mode})
+
+
+@router.post('/stop')
+async def stop_run():
+    global _process
+    if _process and _process.is_alive():
+        _process.terminate()
+        _process.join()
+        return {'status': 'stopped', 'result': _last_result}
+    return {'status': 'idle'}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,6 +3,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressBar = document.getElementById('progressBar');
   const timerEl     = document.getElementById('timer');
   let timerInterval;
+  let currentEvt = null;
+  const stopBtn = document.getElementById('stopBtn');
+
+  if (stopBtn) {
+    stopBtn.addEventListener('click', () => {
+      if (currentEvt) {
+        fetch('/stop', {method: 'POST'}).catch(() => {});
+        currentEvt.close();
+        currentEvt = null;
+        stopTimer();
+      }
+      stopBtn.disabled = true;
+    });
+  }
 
   function startTimer() {
     const start = Date.now();
@@ -33,6 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
       startTimer();
 
       const evt1 = new EventSource('/start1_progress');
+      currentEvt = evt1;
+      if (stopBtn) stopBtn.disabled = false;
       evt1.onmessage = e => {
         const msg = JSON.parse(e.data);
         if (msg.progress !== undefined) {
@@ -42,12 +58,16 @@ document.addEventListener('DOMContentLoaded', () => {
           output.textContent = msg.result;
           stopTimer();
           evt1.close();
+          currentEvt = null;
+          if (stopBtn) stopBtn.disabled = true;
         }
       };
       evt1.onerror = () => {
         output.textContent = 'Ошибка соединения Старт 1.';
         stopTimer();
         evt1.close();
+        currentEvt = null;
+        if (stopBtn) stopBtn.disabled = true;
       };
     });
   }
@@ -61,6 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
       startTimer();
 
       const evt2 = new EventSource('/start2_progress');
+      currentEvt = evt2;
+      if (stopBtn) stopBtn.disabled = false;
       evt2.onmessage = e => {
         const msg = JSON.parse(e.data);
         if (msg.progress !== undefined) {
@@ -70,12 +92,16 @@ document.addEventListener('DOMContentLoaded', () => {
           output.textContent = msg.result;
           stopTimer();
           evt2.close();
+          currentEvt = null;
+          if (stopBtn) stopBtn.disabled = true;
         }
       };
       evt2.onerror = () => {
         output.textContent = 'Ошибка соединения Старт 2.';
         stopTimer();
         evt2.close();
+        currentEvt = null;
+        if (stopBtn) stopBtn.disabled = true;
       };
     });
   }
@@ -89,6 +115,8 @@ if (start3Btn) {
     startTimer();
 
     const evt3 = new EventSource('/start3_progress');
+    currentEvt = evt3;
+    if (stopBtn) stopBtn.disabled = false;
     evt3.onmessage = e => {
       const msg = JSON.parse(e.data);
       if (msg.progress !== undefined) {
@@ -98,12 +126,16 @@ if (start3Btn) {
         output.textContent = msg.result;
         stopTimer();
         evt3.close();
+        currentEvt = null;
+        if (stopBtn) stopBtn.disabled = true;
       }
     };
     evt3.onerror = () => {
       output.textContent = 'Ошибка соединения Старт 3.';
       stopTimer();
       evt3.close();
+      currentEvt = null;
+      if (stopBtn) stopBtn.disabled = true;
     };
   });
 }

--- a/templates/run.html
+++ b/templates/run.html
@@ -9,6 +9,7 @@
       <button id="start1Btn">Базовый</button>
       <button id="start2Btn" style="margin-left: 20px;">Полный</button>
       <button id="start3Btn" style="margin-left: 20px;">Тест прошивки</button>
+      <button id="stopBtn" style="margin-left: 20px;" disabled>СТОП</button>
     </div>
   </div>
 

--- a/templates/tests.html
+++ b/templates/tests.html
@@ -4,7 +4,10 @@
 
   <div style="display:flex; justify-content: space-between; align-items:center; margin-bottom:1rem;">
     <div id="tests-list">Загрузка...</div>
-    <button id="runTestsBtn">Запустить</button>
+    <div>
+      <button id="runTestsBtn">Запустить</button>
+      <button id="stopTestsBtn" style="margin-left:20px;" disabled>СТОП</button>
+    </div>
   </div>
 
   <div id="timer" style="font-weight:bold; margin-bottom:1rem;">00:00</div>
@@ -20,10 +23,12 @@
   document.addEventListener('DOMContentLoaded', () => {
     const listEl = document.getElementById('tests-list');
     const btn = document.getElementById('runTestsBtn');
+    const stopBtn = document.getElementById('stopTestsBtn');
     const outputEl = document.getElementById('testsOutput');
     const progressBar = document.getElementById('progressBar');
     const timerEl = document.getElementById('timer');
     let timerInterval;
+    let abortCtrl = null;
 
     function startTimer() {
       const start = Date.now();
@@ -41,6 +46,16 @@
       clearInterval(timerInterval);
     }
 
+    if (stopBtn) {
+      stopBtn.addEventListener('click', () => {
+        if (abortCtrl) {
+          abortCtrl.abort();
+          fetch('/stop', {method:'POST'}).catch(() => {});
+        }
+        stopBtn.disabled = true;
+      });
+    }
+
     fetch('/api/tests')
       .then(r => r.json())
       .then(data => {
@@ -56,20 +71,27 @@
       progressBar.value = 0;
       outputEl.textContent = 'Запуск...';
       startTimer();
+      abortCtrl = new AbortController();
+      if (stopBtn) stopBtn.disabled = false;
       fetch('/api/tests/run', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({tests: selected})
+        body: JSON.stringify({tests: selected}),
+        signal: abortCtrl.signal
       })
         .then(r => r.json())
         .then(data => {
           progressBar.value = 100;
           stopTimer();
           outputEl.textContent = data.result;
+          abortCtrl = null;
+          if (stopBtn) stopBtn.disabled = true;
         })
         .catch(() => {
           stopTimer();
           outputEl.textContent = 'Ошибка запуска';
+          abortCtrl = null;
+          if (stopBtn) stopBtn.disabled = true;
         });
     });
   });

--- a/tests_runner.py
+++ b/tests_runner.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 import importlib
 from typing import Dict, List
-import acceptance
+import Regression as regression
 
 
 def _discover_tests() -> Dict[str, tuple]:
@@ -42,7 +42,7 @@ def list_tests() -> List[str]:
 
 
 def run_selected_tests(selected: List[str]) -> str:
-    devices = acceptance.load_device_configs('config.txt')
+    devices = regression.load_device_configs('config.txt')
     if not devices:
         return 'Нет устройств в config.txt'
 


### PR DESCRIPTION
## Summary
- switch advanced test runner to use `Regression` config
- add FastAPI `Stop_routes` for running and stopping tests
- show Stop button in run and advanced run pages
- enable stop logic client-side to cancel EventSource or fetch

## Testing
- `python -m py_compile Stop_routes.py tests_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68664025a004832992741b3e3072f525