### PR TITLE
Add async ping precheck for doorphones

### DIFF
--- a/Regression.py
+++ b/Regression.py
@@ -5,6 +5,7 @@ import multiprocessing
 from datetime import datetime
 from progTest.screenshot import run as screenshot_run
 from progTest.ParsProshivka import get_device_info as version_run
+from ping_utils import filter_reachable_devices
 # import progTest.my_task  # пример для расширения обработчиков
 
 
@@ -69,10 +70,15 @@ def run():
     if not devices:
         return "Нет устройств в config.txt"
 
+    devices, warnings = filter_reachable_devices(devices)
+    if not devices:
+        warnings.append("\u26a0\ufe0f \"Не удалось подключиться ни к одному домофону. Тестирование отменено.\"")
+        return "\n".join(warnings)
+
     with multiprocessing.Pool(processes=len(devices)) as pool:
         outcomes = pool.map(handle_one, devices)
 
-    lines = []
+    lines = list(warnings)
     for cfg, result_dict in zip(devices, outcomes):
         cfg_line = " ".join(f"{k}={v}" for k, v in cfg.items())
         lines.append(cfg_line)
@@ -96,3 +102,4 @@ def run():
 
 if __name__ == '__main__':
     print(run())
+

--- a/acceptance.py
+++ b/acceptance.py
@@ -5,6 +5,7 @@ import multiprocessing
 from datetime import datetime
 from progTest.screenshot import run as screenshot_run
 from progTest.ParsProshivka import get_device_info as version_run
+from ping_utils import filter_reachable_devices
 
 def load_device_configs(path='config.txt'):
     """
@@ -80,10 +81,15 @@ def run():
         print(f"[{datetime.now()}] Нет устройств в config.txt")
         return "Нет устройств в config.txt"
 
+    devices, warnings = filter_reachable_devices(devices)
+    if not devices:
+        warnings.append("\u26a0\ufe0f \"Не удалось подключиться ни к одному домофону. Тестирование отменено.\"")
+        return "\n".join(warnings)
+
     with multiprocessing.Pool(processes=len(devices)) as pool:
         outcomes = pool.map(handle_one, devices)
 
-    lines = []
+    lines = list(warnings)
     for cfg, result_dict in zip(devices, outcomes):
         cfg_line = " ".join(f"{k}={v}" for k, v in cfg.items())
         lines.append(cfg_line)
@@ -107,3 +113,4 @@ def run():
 
 if __name__ == "__main__":
     print(run())
+

--- a/ping_utils.py
+++ b/ping_utils.py
@@ -1,0 +1,42 @@
+import asyncio
+import os
+from typing import List, Dict, Tuple
+
+async def _ping(ip: str) -> Tuple[str, bool]:
+    """Ping an IP address once. Return (ip, reachable)."""
+    if os.name == 'nt':
+        cmd = ['ping', '-n', '1', ip]
+    else:
+        cmd = ['ping', '-c', '1', '-W', '1', ip]
+    proc = await asyncio.create_subprocess_exec(*cmd,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL)
+    await proc.communicate()
+    return ip, proc.returncode == 0
+
+async def _check_all(ips: List[str]) -> Dict[str, bool]:
+    coros = [_ping(ip) for ip in ips]
+    results = await asyncio.gather(*coros)
+    return {ip: ok for ip, ok in results}
+
+def check_ips(ips: List[str]) -> Dict[str, bool]:
+    """Synchronously check reachability of IPs using async ping."""
+    if not ips:
+        return {}
+    return asyncio.run(_check_all(ips))
+
+
+def filter_reachable_devices(devices: List[dict]) -> Tuple[List[dict], List[str]]:
+    """Return devices reachable by ping and list of warning messages."""
+    ips = []
+    for d in devices:
+        ip = d.get('IP_CAMERA', '')
+        ip = ip.split(':')[0]
+        if ip and ip not in ips:
+            ips.append(ip)
+    results = check_ips(ips)
+    reachable = {ip for ip, ok in results.items() if ok}
+    warnings = [f"\u274c \"Домофон {ip} недоступен \u2014 исключён из теста\"" for ip, ok in results.items() if not ok]
+    filtered = [d for d in devices if d.get('IP_CAMERA', '').split(':')[0] in reachable]
+    return filtered, warnings
+

--- a/tests_runner.py
+++ b/tests_runner.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import importlib
 from typing import Dict, List
 import Regression as regression
+from ping_utils import filter_reachable_devices
 
 
 def _discover_tests() -> Dict[str, tuple]:
@@ -46,7 +47,12 @@ def run_selected_tests(selected: List[str]) -> str:
     if not devices:
         return 'Нет устройств в config.txt'
 
-    lines: List[str] = []
+    devices, warnings = filter_reachable_devices(devices)
+    if not devices:
+        warnings.append("\u26a0\ufe0f \"Не удалось подключиться ни к одному домофону. Тестирование отменено.\"")
+        return "\n".join(warnings)
+
+    lines: List[str] = list(warnings)
     from io import StringIO
     from contextlib import redirect_stdout
 
@@ -91,3 +97,4 @@ def run_selected_tests(selected: List[str]) -> str:
             continue
         clean.append(ln)
     return '\n'.join(clean)
+


### PR DESCRIPTION
## Summary
- add utility for asynchronous ping check
- filter unreachable devices before running tests
- show warnings when devices are unreachable

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686660ac77a48329ab0dce6b42982698